### PR TITLE
64_APIからの情報取得方法をオリジナルのNear by Searchに変更

### DIFF
--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -1,6 +1,10 @@
 class RestaurantsController < ApplicationController
+  require 'net/http'
+  require 'uri'
+  require 'json'
+
   skip_before_action :require_login, only: %i[index show]
-  before_action :set_google_client
+  # before_action :set_google_client
   before_action :set_restaurant, only: [:tags, :add_tag, :remove_tag, :update_tags]
 
   def index
@@ -61,9 +65,9 @@ class RestaurantsController < ApplicationController
     @restaurant = Restaurant.find(params[:id])
   end
 
-  def set_google_client
-    @client = GooglePlaces::Client.new(ENV['GOOGLE_API_KEY'])
-  end
+  # def set_google_client
+  #   @client = GooglePlaces::Client.new(ENV['GOOGLE_API_KEY'])
+  # end
 
   def search_params
     params.permit(:radius, :place_type, :rating, :closing_time, :latitude, :longitude, :address)
@@ -73,20 +77,51 @@ class RestaurantsController < ApplicationController
     Restaurant.find_or_create_from_api_data(place_data)
   end
 
+  # def fetch_restaurants
+  #   places_data = if params[:latitude].present? && params[:longitude].present?
+  #                   @client.spots(params[:latitude], params[:longitude], search_options).first(20)
+  #                 else
+  #                   []
+  #                 end
+
+  #   @restaurants = places_data.map { |place_data| find_or_create_restaurant(place_data) }
+
+  #   # rating パラメータが存在する場合、その値以上の評価を持つレストランのみをフィルタリング
+  #   if search_params[:rating].present?
+  #     @restaurants = @restaurants.select { |restaurant| restaurant.rating && restaurant.rating >= search_params[:rating].to_f }
+  #   end
+
+  #   @restaurants
+  # end
+
   def fetch_restaurants
-    places_data = if params[:latitude].present? && params[:longitude].present?
-                    @client.spots(params[:latitude], params[:longitude], search_options).first(20)
-                  else
-                    []
-                  end
-
-    @restaurants = places_data.map { |place_data| find_or_create_restaurant(place_data) }
-
+    # NearBySearchのエンドポイントURL
+    base_url = "https://maps.googleapis.com/maps/api/place/nearbysearch/json?"
+  
+    # リクエストのパラメータを設定
+    parameters = {
+      location: "#{params[:latitude]},#{params[:longitude]}",
+      radius: search_params[:radius] || 50,
+      type: search_params[:place_type],
+      key: ENV['GOOGLE_API_KEY'],
+      language: 'ja'
+    }
+  
+    # パラメータをURLにエンコードして結合
+    url = base_url + parameters.to_query
+  
+    # HTTPリクエストを行い、レスポンスを取得
+    response = Net::HTTP.get(URI(url))
+    results = JSON.parse(response)["results"]
+  
+    # レスポンスからレストランのデータを取得または作成
+    @restaurants = results.map { |place_data| find_or_create_restaurant(place_data) }
+  
     # rating パラメータが存在する場合、その値以上の評価を持つレストランのみをフィルタリング
     if search_params[:rating].present?
       @restaurants = @restaurants.select { |restaurant| restaurant.rating && restaurant.rating >= search_params[:rating].to_f }
     end
-
+  
     @restaurants
   end
 
@@ -107,19 +142,19 @@ class RestaurantsController < ApplicationController
     @restaurants
   end
 
-  def search_options
-    radius = params[:radius] || 50
-    {
-      language: 'ja',
-      radius: radius.to_i,
-      types: params[:place_type],
-      closing_time: params[:closing_time],
-      detail: true
-    }
-  end
+  # def search_options
+  #   radius = params[:radius] || 50
+  #   {
+  #     language: 'ja',
+  #     radius: radius.to_i,
+  #     types: params[:place_type],
+  #     closing_time: params[:closing_time],
+  #     detail: true
+  #   }
+  # end
 
-  def search_params
-    params.permit(:radius, :place_type, :rating, :closing_time, :latitude, :longitude, :address)
-  end
+  # def search_params
+  #   params.permit(:radius, :place_type, :rating, :closing_time, :latitude, :longitude, :address)
+  # end
 
 end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,40 +1,60 @@
 class Restaurant < ApplicationRecord
   acts_as_taggable_on :tags
-  has_many :bookmarks
+  has_many :bookmarks, dependent: :destroy
   validates :place_id, presence: true
   validates :name, presence: true
   validates :latitude, presence: true
   validates :longitude, presence: true
 
   def self.find_or_create_from_api_data(data)
-    restaurant = find_or_initialize_by(place_id: data.place_id)
+    restaurant = find_or_initialize_by(place_id: data['place_id'])
     return restaurant if restaurant.persisted?
 
-    if data.photos.present?
-      photo = data.photos.first
-      photo_url = "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=#{photo.photo_reference}&key=#{ENV.fetch(
-        'GOOGLE_API_KEY', nil
-      )}"
-      html_attributions = photo.html_attributions.first
-    end
+    # if data.photos.present?
+    #   photo = data['photos'].first
+    #   photo_url = "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=#{photo.photo_reference}&key=#{ENV.fetch(
+    #     'GOOGLE_API_KEY', nil
+    #   )}"
+    #   html_attributions = photo.html_attributions.first
+    # end
 
+    details = fetch_place_details(data['place_id'])
+
+    if details['photos'].present?
+      photo = details['photos'].first
+      photo_url = "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=#{photo['photo_reference']}&key=#{ENV.fetch('GOOGLE_API_KEY', nil)}"
+      html_attributions = photo['html_attributions'].first
+    end
+  
+    binding.pry
     restaurant.attributes = {
-        place_id: data.place_id,
-        name: data.name,
-        latitude: data.lat,
-        longitude: data.lng,
-        address: data.formatted_address,
-        rating: data.rating,
-        phone_number: data.formatted_phone_number,
-        categories: data.types,
-        price_level: data.price_level,
+        place_id: details['place_id'],
+        name: details['name'],
+        latitude: details['geometry']['location']['lat'],
+        longitude: details['geometry']['location']['lng'],
+        address: details['vicinity'],
+        rating: details['rating'],
+        phone_number: details['formatted_phone_number'],
+        categories: details['types'],
+        price_level: details['price_level'],
         image_url: photo_url,
         html_attributions: html_attributions,
-        url: data.url,
-        opening_hours: data.opening_hours ? data.opening_hours["weekday_text"].join(", ") : "N/A"
+        url: details['url'],
+        opening_hours: details['opening_hours'] ? (details['opening_hours']['open_now'] ? 'Open Now' : 'Closed') : "N/A"
       }
     restaurant.save
     restaurant
+  end
+  
+  def self.fetch_place_details(place_id)
+    base_url = "https://maps.googleapis.com/maps/api/place/details/json"
+    parameters = {
+      place_id: place_id,
+      fields: 'place_id,name,geometry,formatted_phone_number,vicinity,rating,types,price_level,photos,url,opening_hours',
+      key: ENV.fetch('GOOGLE_API_KEY', nil)
+    }
+    response = Net::HTTP.get(URI("#{base_url}?#{parameters.to_query}"))
+    JSON.parse(response)['result']
   end
 
   def bookmark_count

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -25,14 +25,13 @@ class Restaurant < ApplicationRecord
       photo_url = "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=#{photo['photo_reference']}&key=#{ENV.fetch('GOOGLE_API_KEY', nil)}"
       html_attributions = photo['html_attributions'].first
     end
-  
-    binding.pry
+
     restaurant.attributes = {
         place_id: details['place_id'],
         name: details['name'],
         latitude: details['geometry']['location']['lat'],
         longitude: details['geometry']['location']['lng'],
-        address: details['vicinity'],
+        address: details['formatted_address'] || details['vicinity'],
         rating: details['rating'],
         phone_number: details['formatted_phone_number'],
         categories: details['types'],
@@ -40,7 +39,7 @@ class Restaurant < ApplicationRecord
         image_url: photo_url,
         html_attributions: html_attributions,
         url: details['url'],
-        opening_hours: details['opening_hours'] ? (details['opening_hours']['open_now'] ? 'Open Now' : 'Closed') : "N/A"
+        # opening_hours: details['opening_hours'] ? (details['opening_hours']['open_now'] ? 'Open Now' : 'Closed') : "N/A"
       }
     restaurant.save
     restaurant
@@ -51,7 +50,8 @@ class Restaurant < ApplicationRecord
     parameters = {
       place_id: place_id,
       fields: 'place_id,name,geometry,formatted_phone_number,vicinity,rating,types,price_level,photos,url,opening_hours',
-      key: ENV.fetch('GOOGLE_API_KEY', nil)
+      key: ENV.fetch('GOOGLE_API_KEY', nil),
+      language: 'ja'
     }
     response = Net::HTTP.get(URI("#{base_url}?#{parameters.to_query}"))
     JSON.parse(response)['result']

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -39,7 +39,7 @@ class Restaurant < ApplicationRecord
         image_url: photo_url,
         html_attributions: html_attributions,
         url: details['url'],
-        # opening_hours: details['opening_hours'] ? (details['opening_hours']['open_now'] ? 'Open Now' : 'Closed') : "N/A"
+        opening_hours: details['opening_hours'] ? details['opening_hours']["weekday_text"].join(", ") : "N/A"
       }
     restaurant.save
     restaurant

--- a/app/views/restaurants/search.html.erb
+++ b/app/views/restaurants/search.html.erb
@@ -25,10 +25,6 @@
       <%= f.label :rating, "クチコミスコア" %>
       <%= f.select :rating, [["選択しない", nil], ["1以上", 1], ["2以上", 2], ["3以上", 3], ["4以上", 4], ["5", 5]], selected: params[:rating], include_blank: false %>
     </div>
-    <%# <div class="mb-6"> %>
-      <%# <%= f.label :closing_time, '閉店時間' %>
-      <%# <%= f.range_field :closing_time, value: 22, min: 0, max: 24, step: 1 %>
-    <%# </div> %>
     <div class="mb-6">
       <%= f.submit '検索', id: 'search-address',class:'btn' %>
     </div>

--- a/app/views/restaurants/show.html.erb
+++ b/app/views/restaurants/show.html.erb
@@ -1,5 +1,5 @@
 <div class="container mx-auto px-4">
-  <div class="flex items-center justify-between">
+  <div class="mt-4 flex items-center justify-between">
     <h1><strong><%= @restaurant.name %></strong></h1>
     <div class="line-it-button" data-lang="ja" data-type="share-b" data-env="REAL" data-url="https://hashigo.fly.dev//restaurants/<%= @restaurant.id %>" data-color="default" data-size="small" data-count="false" data-ver="3" style="display: none;"></div>
   </div>
@@ -13,8 +13,10 @@
     <%= render partial: 'tags_section', locals: { restaurant: @restaurant } %>
   <% end %>
   <li><strong>URL:</strong> <%= link_to @restaurant.url, @restaurant.url, target: "_blank" %></p>
-  <li><strong>Opening Hours:</strong></p>
-  <%= simple_format(@restaurant.opening_hours.gsub(",", "\n")) %>
+  <% if @restaurant.opening_hours %>
+    <li><strong>Opening Hours:</strong></p>
+    <%= simple_format(@restaurant.opening_hours.gsub(",", "\n")) %>
+  <% end %>
     <%# <p><strong>Categories:</strong> <%= @restaurant.categories %></p>
 
   <%= image_tag (@restaurant.image_url || 'default_image.jpg'), alt: @restaurant.name %>


### PR DESCRIPTION
closes #64 
- APIからの情報取得方法をgem google_placesからオリジナルのNear by Searchに変更
- fetch_restaurants, fetch_restaurants_from_addressの変更
- 合わせてrestaurants modelを修正
- fetch_places_from_apiでAPI呼び出し部を切り分け
- 「現在地から検索」の場合には「現在営業中」の店舗のみ取得されるよう修正